### PR TITLE
Change main page to account for Chrome delisting

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -25,7 +25,10 @@
     <meta name="application-name" content="MetaMask">
     <meta name="theme-color" content="#f68c24">
 
+    <!-- Swapped out since Chrome has de-listed our extension. Can un-comment to re-enable.
     <link rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/nkbihfbeogaeaoehlefnkodbefgpgknn">
+    -->
+    <link rel="chrome-webstore-item" href="https://consensys.zendesk.com/hc/en-us/articles/360004134152-How-to-Install-MetaMask-Manually">
     <link rel="stylesheet" href="./css/bundle.css">
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
@@ -48,12 +51,12 @@
         <h1>MetaMask</h1>
         <h2>Brings Ethereum to your browser </h2>
 
-        <a href="https://chrome.google.com/webstore/detail/nkbihfbeogaeaoehlefnkodbefgpgknn" id="main-install-button" class="cta" target="_blank">Get Chrome Extension</a>
+        <a href="https://chrome.google.com/webstore/detail/nkbihfbeogaeaoehlefnkodbefgpgknn" id="main-install-button" class="cta" target="_blank">Get Firefox Extension</a>
         <p>
 
-        <a href="https://chrome.google.com/webstore/detail/nkbihfbeogaeaoehlefnkodbefgpgknn" class="download-link download-link-chrome" target="_blank">Chrome</a>
         <a href="https://addons.mozilla.org/en-US/firefox/addon/ether-metamask/" class="download-link download-link-firefox" target="_blank">Firefox</a>
         <a href="https://addons.opera.com/en/extensions/details/metamask/" class="download-link download-link-opera" target="_blank">Opera</a>
+        <a href="https://consensys.zendesk.com/hc/en-us/articles/360004134152-How-to-Install-MetaMask-Manually" class="download-link download-link-chrome" target="_blank">Chrome or other Browsers</a>
 
         <p>OR</p>
         <a href="https://brave.com/" class="cta" target="_blank">Get Brave Browser</a>
@@ -71,7 +74,7 @@
           </div>
 
           <div class="columns six plugin-link">
-            <a href="https://chrome.google.com/webstore/detail/nkbihfbeogaeaoehlefnkodbefgpgknn" id="nav-install-button" class="cta small" target="_blank">Get Chrome Extension</a>
+            <a href="https://chrome.google.com/webstore/detail/nkbihfbeogaeaoehlefnkodbefgpgknn" id="nav-install-button" class="cta small" target="_blank">Get Firefox Extension</a>
           </div>
 
         </div>


### PR DESCRIPTION
- Switch main install links to Firefox.
- Switch Chrome install link to guide to manual installation.

We could wait a little time for Google to reply, or we can make these changes now.

Still needs some graphical updates to remove Chrome as the primary browser representation.