### PR TITLE
Remove getacute.io widget

### DIFF
--- a/401.html
+++ b/401.html
@@ -37,7 +37,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
 </head>
 <body>
   <div class="utility-page-wrap">

--- a/404.html
+++ b/404.html
@@ -44,7 +44,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
 </head>
 <body>
   <div class="utility-page-wrap">

--- a/about.html
+++ b/about.html
@@ -44,7 +44,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
   <script>
   window.actSettings = {
    token: "4bf7df5dee1d618c5774101ce5ba53be9ae38dad82f8ad2f5362bb5ba77ebe4c",
@@ -62,7 +61,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
 </head>
 <body class="body-2">
   <div data-collapse="medium" data-animation="default" data-duration="200" data-easing="ease-in-out" data-easing2="ease-in-out" role="banner" class="navigation-bar dark w-nav">

--- a/attributions.html
+++ b/attributions.html
@@ -37,7 +37,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
   <script>
   window.actSettings = {
    token: "4bf7df5dee1d618c5774101ce5ba53be9ae38dad82f8ad2f5362bb5ba77ebe4c",
@@ -55,7 +54,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
 </head>
 <body>
   <div data-collapse="medium" data-animation="default" data-duration="200" data-easing="ease-in-out" data-easing2="ease-in-out" role="banner" class="navigation-bar dark w-nav">

--- a/cla.html
+++ b/cla.html
@@ -44,7 +44,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
   <script>
   window.actSettings = {
    token: "4bf7df5dee1d618c5774101ce5ba53be9ae38dad82f8ad2f5362bb5ba77ebe4c",
@@ -62,7 +61,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
 </head>
 <body>
   <div data-collapse="medium" data-animation="default" data-duration="200" data-easing="ease-in-out" data-easing2="ease-in-out" role="banner" class="navigation-bar dark w-nav">

--- a/detail_team.html
+++ b/detail_team.html
@@ -35,7 +35,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
 </head>
 <body>
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=5b479ea1731aa13135a70342" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>

--- a/download.html
+++ b/download.html
@@ -44,7 +44,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/bowser/1.9.4/bowser.min.js" integrity="sha384-2wrSrTEHqvdtiVAZygJZuYUeKryvoEf1n4xaniOxF7VWWtiZOMGiVx6hTop4W7Nz" crossorigin="anonymous"></script>
   <script>
   window.actSettings = {
@@ -63,7 +62,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
 </head>
 <body>
   <div data-collapse="medium" data-animation="default" data-duration="200" data-easing="ease-in-out" data-easing2="ease-in-out" role="banner" class="navigation-bar dark w-nav">

--- a/faqs.html
+++ b/faqs.html
@@ -37,7 +37,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
   <script>
   window.actSettings = {
    token: "4bf7df5dee1d618c5774101ce5ba53be9ae38dad82f8ad2f5362bb5ba77ebe4c",
@@ -55,7 +54,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
 </head>
 <body class="body-3">
   <div data-collapse="medium" data-animation="default" data-duration="200" data-easing="ease-in-out" data-easing2="ease-in-out" role="banner" class="navigation-bar dark w-nav">

--- a/index.html
+++ b/index.html
@@ -44,7 +44,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
   <script>
   window.actSettings = {
    token: "4bf7df5dee1d618c5774101ce5ba53be9ae38dad82f8ad2f5362bb5ba77ebe4c",
@@ -62,7 +61,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
 </head>
 <body>
   <div data-collapse="medium" data-animation="default" data-duration="200" data-easing="ease-in-out" data-easing2="ease-in-out" role="banner" class="navigation-bar dark w-nav">

--- a/mobile-launch.html
+++ b/mobile-launch.html
@@ -37,7 +37,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
   <script>
   window.actSettings = {
    token: "4bf7df5dee1d618c5774101ce5ba53be9ae38dad82f8ad2f5362bb5ba77ebe4c",
@@ -55,7 +54,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
 </head>
 <body class="mobile-launch">
   <div class="section-11"><img src="images/favicon-256.png" width="37" alt="" class="image-14"></div>

--- a/newsletter.html
+++ b/newsletter.html
@@ -44,7 +44,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
   <script>
   window.actSettings = {
    token: "4bf7df5dee1d618c5774101ce5ba53be9ae38dad82f8ad2f5362bb5ba77ebe4c",
@@ -62,7 +61,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
 </head>
 <body>
   <div data-collapse="medium" data-animation="default" data-duration="200" data-easing="ease-in-out" data-easing2="ease-in-out" role="banner" class="navigation-bar dark w-nav">

--- a/privacy.html
+++ b/privacy.html
@@ -44,7 +44,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
   <script>
   window.actSettings = {
    token: "4bf7df5dee1d618c5774101ce5ba53be9ae38dad82f8ad2f5362bb5ba77ebe4c",
@@ -62,7 +61,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
 </head>
 <body>
   <div data-collapse="medium" data-animation="default" data-duration="200" data-easing="ease-in-out" data-easing2="ease-in-out" role="banner" class="navigation-bar dark w-nav">

--- a/terms.html
+++ b/terms.html
@@ -44,7 +44,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
   <script>
   window.actSettings = {
    token: "4bf7df5dee1d618c5774101ce5ba53be9ae38dad82f8ad2f5362bb5ba77ebe4c",
@@ -62,7 +61,6 @@
    }
  };
 </script>
-  <script src="https://assets.getacute.io/assets/widget.js"></script>
 </head>
 <body>
   <div data-collapse="medium" data-animation="default" data-duration="200" data-easing="ease-in-out" data-easing2="ease-in-out" role="banner" class="navigation-bar dark w-nav">


### PR DESCRIPTION
The getacute.io widget was added to Google's phishing list, and was causing metamask.io to trigger the Chrome phishing warning.

https://transparencyreport.google.com/safe-browsing/search?url=https:%2F%2Fassets.getacute.io%2Fassets%2Fwidget.js&hl=en-US

This error currently appearing in console (no idea if related, but that's the script anyway):

![image](https://user-images.githubusercontent.com/25517051/100052226-548f6d80-2dd2-11eb-96bc-4b9176116027.png)
