### PR TITLE
Remove security disclosure link

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,7 +244,6 @@
           <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="footer-link">Support</a>
           <a href="https://medium.com/metamask" rel="noreferer, noopener" target="_blank" class="footer-link">Blog</a>
           <a href="https://twitter.com/metamask" rel="noreferer, noopener" target="_blank" class="footer-link">Twitter</a>
-          <a href="mailto:security@metamask.io" rel="noreferer, noopener" class="footer-link">Security Disclosures</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
`security@metamask.io` is getting spammed with irrelevant messages. Should be removed from the website and kept in the security policy.