### PR TITLE
Url quick fix 

### DIFF
--- a/updates/password-required.html
+++ b/updates/password-required.html
@@ -88,7 +88,7 @@
         <h3>Do you use biometrics to login and don’t remember your password?</h3>
         <p>If you do not remember your password and use biometric to login:<br></p>
         <ol role="list">
-          <li>Login immediately and <a href="https://www.google.com/url?q=https://metamask.zendesk.com/hc/en-us/articles/360015290032-How-to-Reveal-Your-Seed-Phrase&amp;sa=D&amp;source=editors&amp;ust=1625260237389000&amp;usg=AOvVaw1tdreUTabHw1t0LEsSnWGF" target="_blank">back up your Secret Recovery Phrase</a>. Do not log out of MetaMask before you’ve backed up your Secret Recovery Phrase. </li>
+          <li>Login immediately and <a href="https://metamask.zendesk.com/hc/en-us/articles/360015290032-How-to-Reveal-Your-Seed-Phrase" target="_blank">back up your Secret Recovery Phrase</a>. Do not log out of MetaMask before you’ve backed up your Secret Recovery Phrase. </li>
           <li>You cannot reset your password in Settings unless you have your current password.</li>
         </ol>
         <p>What happens if you get locked out and do not remember your password but you have your Secret Recovery Phrase backed up?</p>


### PR DESCRIPTION
removed “https://www.google.com/url?q=“ from the URL on “back up your Secret Recovery Phrase” linked text.