### PR TITLE
Updates to Support dropdown links

### DIFF
--- a/1559.html
+++ b/1559.html
@@ -61,8 +61,8 @@ document.getElementById("downloadButtonPageSwaps").onclick = function(){
           </div>
           <nav class="dropdown-list w-dropdown-list">
             <a href="faqs.html" class="dropdown-link w-dropdown-link">FAQs</a>
-            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
-            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Knowledge Base<br></a>
+            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
+            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Community<br></a>
           </nav>
         </div>
         <div data-hover="1" data-delay="0" class="w-dropdown">

--- a/about.html
+++ b/about.html
@@ -51,8 +51,8 @@
           </div>
           <nav class="dropdown-list w-dropdown-list">
             <a href="faqs.html" class="dropdown-link w-dropdown-link">FAQs</a>
-            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
-            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Knowledge Base<br></a>
+            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
+            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Community<br></a>
           </nav>
         </div>
         <div data-hover="true" data-delay="0" class="w-dropdown">

--- a/attributions.html
+++ b/attributions.html
@@ -67,8 +67,8 @@
           </div>
           <nav class="dropdown-list w-dropdown-list">
             <a href="faqs.html" class="dropdown-link w-dropdown-link">FAQs</a>
-            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
-            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Knowledge Base<br></a>
+            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
+            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Community<br></a>
           </nav>
         </div>
         <div data-hover="1" data-delay="0" class="w-dropdown">

--- a/beta-terms.html
+++ b/beta-terms.html
@@ -49,8 +49,8 @@
           </div>
           <nav class="dropdown-list w-dropdown-list">
             <a href="faqs.html" class="dropdown-link w-dropdown-link">FAQs</a>
-            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
-            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Knowledge Base<br></a>
+            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
+            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Community<br></a>
           </nav>
         </div>
         <div data-hover="1" data-delay="0" class="w-dropdown">

--- a/cla.html
+++ b/cla.html
@@ -51,8 +51,8 @@
           </div>
           <nav class="dropdown-list w-dropdown-list">
             <a href="faqs.html" class="dropdown-link w-dropdown-link">FAQs</a>
-            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
-            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Knowledge Base<br></a>
+            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
+            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Community<br></a>
           </nav>
         </div>
         <div data-hover="1" data-delay="0" class="w-dropdown">

--- a/download.html
+++ b/download.html
@@ -52,8 +52,8 @@
           </div>
           <nav class="dropdown-list w-dropdown-list">
             <a href="faqs.html" class="dropdown-link w-dropdown-link">FAQs</a>
-            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
-            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Knowledge Base<br></a>
+            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
+            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Community<br></a>
           </nav>
         </div>
         <div data-hover="1" data-delay="0" class="w-dropdown">

--- a/faqs.html
+++ b/faqs.html
@@ -49,8 +49,8 @@
           </div>
           <nav class="dropdown-list w-dropdown-list">
             <a href="faqs.html" aria-current="page" class="dropdown-link w-dropdown-link w--current">FAQs</a>
-            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
-            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Knowledge Base<br></a>
+            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
+            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Community<br></a>
           </nav>
         </div>
         <div data-hover="1" data-delay="0" class="w-dropdown">

--- a/index.html
+++ b/index.html
@@ -51,8 +51,8 @@
           </div>
           <nav class="dropdown-list w-dropdown-list">
             <a href="faqs.html" class="dropdown-link w-dropdown-link">FAQs</a>
-            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
-            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Knowledge Base<br></a>
+            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
+            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Community<br></a>
           </nav>
         </div>
         <div data-hover="1" data-delay="0" class="w-dropdown">

--- a/institutions.html
+++ b/institutions.html
@@ -51,8 +51,8 @@
           </div>
           <nav class="dropdown-list w-dropdown-list">
             <a href="faqs.html" class="dropdown-link w-dropdown-link">FAQs</a>
-            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
-            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Knowledge Base<br></a>
+            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
+            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Community<br></a>
           </nav>
         </div>
         <div data-hover="true" data-delay="0" class="w-dropdown">

--- a/institutions/custody.html
+++ b/institutions/custody.html
@@ -51,8 +51,8 @@
           </div>
           <nav class="dropdown-list w-dropdown-list">
             <a href="../faqs.html" class="dropdown-link w-dropdown-link">FAQs</a>
-            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
-            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Knowledge Base<br></a>
+            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
+            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Community<br></a>
           </nav>
         </div>
         <div data-hover="true" data-delay="0" class="w-dropdown">

--- a/institutions/faq.html
+++ b/institutions/faq.html
@@ -56,8 +56,8 @@ list-style-position: inside!important;
           </div>
           <nav class="dropdown-list w-dropdown-list">
             <a href="../faqs.html" class="dropdown-link w-dropdown-link">FAQs</a>
-            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
-            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Knowledge Base<br></a>
+            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
+            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Community<br></a>
           </nav>
         </div>
         <div data-hover="true" data-delay="0" class="w-dropdown">

--- a/newsletter.html
+++ b/newsletter.html
@@ -51,8 +51,8 @@
           </div>
           <nav class="dropdown-list w-dropdown-list">
             <a href="faqs.html" class="dropdown-link w-dropdown-link">FAQs</a>
-            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
-            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Knowledge Base<br></a>
+            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
+            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Community<br></a>
           </nav>
         </div>
         <div data-hover="1" data-delay="0" class="w-dropdown">

--- a/sitemap.html
+++ b/sitemap.html
@@ -49,8 +49,8 @@
           </div>
           <nav class="dropdown-list w-dropdown-list">
             <a href="faqs.html" class="dropdown-link w-dropdown-link">FAQs</a>
-            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
-            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Knowledge Base<br></a>
+            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
+            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Community<br></a>
           </nav>
         </div>
         <div data-hover="1" data-delay="0" class="w-dropdown">

--- a/swaps.html
+++ b/swaps.html
@@ -61,8 +61,8 @@ document.getElementById("downloadButtonPageSwaps").onclick = function(){
           </div>
           <nav class="dropdown-list w-dropdown-list">
             <a href="faqs.html" class="dropdown-link w-dropdown-link">FAQs</a>
-            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
-            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Knowledge Base<br></a>
+            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
+            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Community<br></a>
           </nav>
         </div>
         <div data-hover="1" data-delay="0" class="w-dropdown">

--- a/updates/password-required.html
+++ b/updates/password-required.html
@@ -49,8 +49,8 @@
           </div>
           <nav class="dropdown-list w-dropdown-list">
             <a href="../faqs.html" class="dropdown-link w-dropdown-link">FAQs</a>
-            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
-            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Knowledge Base<br></a>
+            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
+            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Community<br></a>
           </nav>
         </div>
         <div data-hover="1" data-delay="0" class="w-dropdown">

--- a/updates/v1-security-update.html
+++ b/updates/v1-security-update.html
@@ -49,8 +49,8 @@
           </div>
           <nav class="dropdown-list w-dropdown-list">
             <a href="../faqs.html" class="dropdown-link w-dropdown-link">FAQs</a>
-            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
-            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Knowledge Base<br></a>
+            <a href="https://metamask.zendesk.com/hc/en-us" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Get Support</a>
+            <a href="https://community.metamask.io/" rel="noreferer, noopener" target="_blank" class="dropdown-link w-dropdown-link">Community<br></a>
           </nav>
         </div>
         <div data-hover="1" data-delay="0" class="w-dropdown">


### PR DESCRIPTION
Under the "Support" dropdown:

1. Updates the "Get Support" link to point from `https://community.metamask.io/` -> `https://metamask.zendesk.com/hc/en-us`
2. Updates the "Knowledge Base" link text -> "Community", and changes the link to point from `https://metamask.zendesk.com/hc/en-us` -> `https://community.metamask.io/`
3. 
<img width="645" alt="Screen Shot 2021-11-14 at 3 53 56 PM" src="https://user-images.githubusercontent.com/8732757/141822224-feab507f-5232-456d-ba7e-e24115457d7f.png">


