### PR TITLE
add gatsby-plugin-linkedin-insight

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -83,6 +83,13 @@ if (env.errors) {
         },
       },
       {
+        resolve: `gatsby-plugin-linkedin-insight`,
+        options: {
+          partnerId: `451393`,
+          includeInDevelopment: true
+        }
+      },
+      {
         resolve: `gatsby-plugin-sitemap`,
         options: {
           query: `

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gatsby-cli": "^2.7.57",
     "gatsby-image": "^2.2.25",
     "gatsby-plugin-google-analytics": "^4.6.0",
+    "gatsby-plugin-linkedin-insight": "^1.0.1",
     "gatsby-plugin-manifest": "^2.2.21",
     "gatsby-plugin-offline": "^3.0.13",
     "gatsby-plugin-preact": "^4.7.0",


### PR DESCRIPTION
**GH:** https://github.com/ConsenSys/dx-team/issues/1223
**Desc:** This PR adds a plugin that installs the LinkedIn tracking pixel to the site.