### PR TITLE
Remove PWA manifest plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -60,18 +60,6 @@ if (env.errors) {
         },
       },
       {
-        resolve: `gatsby-plugin-manifest`,
-        options: {
-          name: 'gatsby-starter-default',
-          short_name: 'starter',
-          start_url: '/',
-          background_color: '#FFFFFF',
-          theme_color: '#333333',
-          display: 'minimal-ui',
-          icon: `${__dirname}/src/images/metamask-logo.png`,
-        },
-      },
-      {
         resolve: `gatsby-source-filesystem`,
         options: {
           name: `images`,


### PR DESCRIPTION
This looks like an obvious mistake -- our website is not intended to be a PWA
https://www.gatsbyjs.com/plugins/gatsby-plugin-manifest/