### PR TITLE
Added `twitter:image:src` meta tag to support Twitter sharing preview image

### DIFF
--- a/src/components/Seo.js
+++ b/src/components/Seo.js
@@ -57,6 +57,7 @@ const SEO = props => {
     ...getMetaTags('title', seo.title),
     ...getMetaTags('description', seo.desc),
     ...getMetaTags('image', urlImageMetaClean),
+    ...getMetaTags('image:src', urlImageMetaClean),
     pathname !== pagePath
       ? {
           'http-equiv': 'refresh',


### PR DESCRIPTION
There was previously a meta tag `twitter:image` but from experience we need to use `twitter:image:src`