### PR TITLE
fix: integrate.yml update actions

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -77,7 +77,7 @@ jobs:
           CI: true
 
       - name: Deploy 🚀
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -77,8 +77,8 @@ jobs:
           CI: true
 
       - name: Deploy 🚀
-        uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          personal_token: ${{ secrets.PUBLISH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
           publish_dir: ./public


### PR DESCRIPTION
To enable GitHub Pages deployment again, we need to update the peaceiris/actions-gh-pages action to the latest version

I don't have the permissions to update settings > actions > general > Allow specified actions and reusable workflows