### PR TITLE
Enhance security of integrate.yml

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -83,6 +83,6 @@ jobs:
       - name: Deploy 🚀
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.DEPLOY_TOKEN }}
           publish_branch: gh-pages
           publish_dir: ./public

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -10,12 +10,9 @@ on:
 jobs:
   build_deploy:
     runs-on: ubuntu-latest
-    environment: github-pages
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
-    permissions:
-      contents: write
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
@@ -76,6 +73,13 @@ jobs:
         env:
           CI: true
 
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build_deploy
+    environment: github-pages
+    permissions:
+      contents: write
+    steps:
       - name: Deploy 🚀
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
         with:

--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -43,36 +43,21 @@ jobs:
         with:
           node-version-file: ".nvmrc"
 
-      - name: Cache Gatsby 📦
-        uses: actions/cache@v4
-        id: cache-gatsby
-        with:
-          path: |
-            .cache
-            public
-          key: ${{ runner.os }}-cache-gatsby-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-cache-gatsby
-
-      - name: Cache Modules 📦
-        id: cache-modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            node_modules
-          key: ${{ runner.os }}-cache-modules-${{ hashFiles('**/yarn.lock')}}
-          restore-keys: |
-            ${{ runner.os }}-cache-modules-
-
       - name: Install Dependencies ⏳
-        if: steps.cache-modules.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
 
       - name: Build 🔧
         run: yarn deploy
         env:
           CI: true
-
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-release-artifacts-${{ github.sha }}
+          retention-days: 1
+          include-hidden-files: true
+          path: |
+            ./public
   deploy:
     runs-on: ubuntu-latest
     needs: build_deploy
@@ -80,6 +65,10 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Fetch build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: publish-release-artifacts-${{ github.sha }}
       - name: Deploy 🚀
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
         with:


### PR DESCRIPTION
## Summary

This pull request refactors integrate.yml to bring a variety of security improvements.

1. The `github-pages` environment provides access to the deployment token used to publish releases. Refactoring this job such that we are not installing third party dependencies in the same environment as this token allows for further protection against supply chain attacks.
2. Removing usage of actions/cache helps protect against potential cache poisoning attacks as seen in this [article](https://socket.dev/blog/ultralytics-pypi-package-compromised-through-github-actions-cache-poisoning).
3. Updating the deployment token from being `GITHUB_TOKEN` to being `DEPLOY_TOKEN` allows us to further lockdown on changes made to the GitHub pages branch.
