### PR TITLE
fix: disallow search engines from crawling the gh pages

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -120,18 +120,9 @@ if (env.errors) {
       },
       {
         resolve: 'gatsby-plugin-robots-txt',
-        options:
-          activeEnv === 'production'
-            ? {
-                host: 'https://metamask.io',
-                sitemap: 'https://metamask.io/sitemap-index.xml',
-                policy: [{ userAgent: '*', allow: '/' }],
-              }
-            : {
-                host: 'https://metamask.consensys.io',
-                sitemap: 'https://metamask.consensys.io/sitemap-index.xml',
-                policy: [{ userAgent: '*', disallow: '/' }],
-              },
+        options: {
+          policy: [{ userAgent: '*', disallow: '/' }],
+        },
       },
       {
         resolve: 'gatsby-plugin-launchdarkly',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Forces `robots.txt` to disallow all crawling in every environment, which could unintentionally de-index the production site if this config is deployed there.
> 
> **Overview**
> Updates `gatsby-plugin-robots-txt` configuration to **always** emit a `Disallow: /` policy, removing the previous environment-based behavior that allowed crawling in production and blocked it elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8c9aa28e4a1add5ca64dd970fe0a48c2d765299. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->